### PR TITLE
dont store datastore data on disk by default

### DIFF
--- a/datastore/Dockerfile
+++ b/datastore/Dockerfile
@@ -5,11 +5,13 @@ RUN gcloud components install beta cloud-datastore-emulator
 ENV DATASTORE_CONSISTENCY=0.9 \
     DATASTORE_DATA_DIR=/var/data \
     HOST_PORT=0.0.0.0:8081 \
-    CLOUDSDK_CORE_PROJECT=zing-dev
+    CLOUDSDK_CORE_PROJECT=zing-dev \
+    DATASTORE_DISK_FLAG=--no-store-on-disk
 
 EXPOSE 8081
 
 CMD gcloud beta emulators datastore start \
     --consistency=$DATASTORE_CONSISTENCY \
     --host-port=$HOST_PORT \
-    --data-dir=$DATASTORE_DATA_DIR
+    --data-dir=$DATASTORE_DATA_DIR \
+    $DATASTORE_DISK_FLAG


### PR DESCRIPTION
In order for the /reset endpoint to work, we must have the --no-store-on-disk flag set.  Since this is vital for integration tests, this change sets that flag by default.  It can be overridden by setting the environment variable
DATSTORE_DISK_FLAG=--store-on-disk