### PR TITLE
Pin version of pubsub to 178.0.0

### DIFF
--- a/pubsub/Dockerfile
+++ b/pubsub/Dockerfile
@@ -1,11 +1,13 @@
-FROM google/cloud-sdk:alpine                                            
-RUN apk --update --no-cache add openjdk7-jre
-RUN gcloud components install beta pubsub-emulator
+FROM alpine                                            
+RUN apk --update --no-cache add openjdk7-jre curl python bash
+RUN curl https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-178.0.0-linux-x86_64.tar.gz | tar xz
+RUN ./google-cloud-sdk/bin/gcloud components install beta pubsub-emulator --quiet
 
 ENV CLOUDSDK_CORE_PROJECT=zing-dev \
     HOST_PORT=0.0.0.0:8085
 
 EXPOSE 8085
 
-CMD gcloud beta emulators pubsub start \
-    --host-port=$HOST_PORT
+CMD ./google-cloud-sdk/bin/gcloud beta emulators pubsub start \
+    --host-port=$HOST_PORT \
+    --verbosity=warning


### PR DESCRIPTION
This pins the version of the pubsub emulator to 178.0.0.  The emulator versions are tied to the google cloud sdk version, so I had to switch to a base image that doesn't already have the SDK installed, and install an older version manually.  This is documented here:
https://cloud.google.com/sdk/downloads#versioned

This also sets the verbosity of the emulator to "warning"
