### PR TITLE
Update datastore emulator to use jdk8

### DIFF
--- a/datastore/Dockerfile
+++ b/datastore/Dockerfile
@@ -1,5 +1,5 @@
 FROM google/cloud-sdk:alpine                                            
-RUN apk --update --no-cache add openjdk7-jre
+RUN apk --update --no-cache add openjdk8-jre
 RUN gcloud components install beta cloud-datastore-emulator
 
 ENV DATASTORE_CONSISTENCY=0.9 \


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZING-2258

The datastore emulator requires jdk8 now.