### PR TITLE
ZING-28400: update versions

### DIFF
--- a/bigtable/Dockerfile
+++ b/bigtable/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:435.0.1-alpine                                         
+FROM google/cloud-sdk:alpine                                         
 RUN gcloud components install bigtable beta
 
 ENV CLOUDSDK_CORE_PROJECT=zing-dev \

--- a/bigtable/Dockerfile
+++ b/bigtable/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:alpine                                            
+FROM google/cloud-sdk:435.0.1-alpine                                         
 RUN gcloud components install bigtable beta
 
 ENV CLOUDSDK_CORE_PROJECT=zing-dev \

--- a/bigtable/Dockerfile
+++ b/bigtable/Dockerfile
@@ -1,7 +1,6 @@
 FROM google/cloud-sdk:alpine                                            
 RUN gcloud components install bigtable beta
 
-
 ENV CLOUDSDK_CORE_PROJECT=zing-dev \
     HOST_PORT=0.0.0.0:8086
 

--- a/datastore/Dockerfile
+++ b/datastore/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:435.0.1-alpine                                            
+FROM google/cloud-sdk:alpine                                            
 RUN apk --update --no-cache add openjdk8-jre
 RUN gcloud components install beta cloud-datastore-emulator
 

--- a/datastore/Dockerfile
+++ b/datastore/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:294.0.0-alpine                                            
+FROM google/cloud-sdk:435.0.1-alpine                                            
 RUN apk --update --no-cache add openjdk8-jre
 RUN gcloud components install beta cloud-datastore-emulator
 

--- a/firestore/Dockerfile
+++ b/firestore/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:435.0.1-alpine                                         
+FROM google/cloud-sdk:alpine                                         
 RUN apk --update --no-cache add openjdk8-jre
 RUN gcloud components install beta cloud-firestore-emulator
 

--- a/firestore/Dockerfile
+++ b/firestore/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:alpine                                            
+FROM google/cloud-sdk:435.0.1-alpine                                         
 RUN apk --update --no-cache add openjdk8-jre
 RUN gcloud components install beta cloud-firestore-emulator
 

--- a/pubsub/Dockerfile
+++ b/pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:435.0.1-alpine                                        
+FROM google/cloud-sdk:alpine                                        
 RUN apk --update --no-cache add openjdk8-jre ca-certificates
 RUN gcloud components install beta pubsub-emulator --quiet
 

--- a/pubsub/Dockerfile
+++ b/pubsub/Dockerfile
@@ -1,13 +1,12 @@
-FROM alpine                                            
-RUN apk --update --no-cache add openjdk7-jre curl python bash ca-certificates
-RUN curl https://storage.googleapis.com/cloud-sdk-release/google-cloud-sdk-178.0.0-linux-x86_64.tar.gz | tar xz
-RUN ./google-cloud-sdk/bin/gcloud components install beta pubsub-emulator --quiet
+FROM google/cloud-sdk:435.0.1-alpine                                        
+RUN apk --update --no-cache add openjdk8-jre ca-certificates
+RUN gcloud components install beta pubsub-emulator --quiet
 
 ENV CLOUDSDK_CORE_PROJECT=zing-dev \
     HOST_PORT=0.0.0.0:8085
 
 EXPOSE 8085
 
-CMD ./google-cloud-sdk/bin/gcloud beta emulators pubsub start \
+CMD gcloud beta emulators pubsub start \
     --host-port=$HOST_PORT \
     --verbosity=warning


### PR DESCRIPTION
Some containers didn't specify a cloud-sdk version and therefore were always pulling the latest available version on every `docker build`. Should we specify a version in every Dockerfile instead? (like in pubsub and datastore)